### PR TITLE
Configurar un Dag sin procesamiento , ni consulta

### DIFF
--- a/airflow/dags/DAG_UniversidadNacionaldeJujuy.py
+++ b/airflow/dags/DAG_UniversidadNacionaldeJujuy.py
@@ -1,0 +1,22 @@
+from asyncio.format_helpers import extract_stack
+import operator
+from airflow import DAG 
+from datetime import datetime,timedelta
+from airflow.operators.dummy  import DummyOperator
+
+"""
+configuration of the DAG without queries or processing
+for National University of Jujuy
+"""
+with DAG (
+          'DAG_Universidad_Nacional_de_Jujuy',
+          description='DAG para la Universidad Nacional de Jujuy',
+          scheduler_interval=timedelta(hours=1), #execute each one hour
+          start_date=datetime(2022,6,19)
+          ) as dag:
+            #only the tasks of extrancting data , transforming them and uploading them are declare  
+                extract_task=DummyOperator(task_id='extract_task')
+                transform_task=DummyOperator(task_id='transform_task')
+                load_task=DummyOperator(task_id='transform_task')
+            #the execution order of the DAG
+                extract_task >> transform_task >> load_task

--- a/airflow/dags/DAG_UniversidaddePalermo.py
+++ b/airflow/dags/DAG_UniversidaddePalermo.py
@@ -1,0 +1,21 @@
+from airflow import DAG 
+from datetime import datetime
+from airflow.operators.dummy  import DummyOperator
+
+
+"""
+configuration of the DAG without queries or processing 
+for University of Palermo
+"""
+with DAG(
+        'DAG_Universidad_de_Palermo',
+        description='DAG para la Universidad de Palermo',
+        schedule_interval= "@hourly", #execute each one hour
+        start_date=datetime(2022,6,19)
+        ) as dag:
+        #only the tasks of extrancting data , transforming them and uploading them are declare
+            extract_task=DummyOperator(task_id='extract_task')
+            transform_task=DummyOperator(task_id='transform_task')
+            load_task=DummyOperator(task_id='load_task')
+        #the execution order of the DAG
+            extract_task >> transform_task >> load_task


### PR DESCRIPTION
Para el Grupo de Universidades del grupo C.

COMO: Analista de datos
QUIERO: Configurar un DAG, sin consultas, ni procesamiento
PARA: Hacer un ETL para 2 universidades distintas.

Criterios de aceptación: 
Configurar el DAG para procese las siguientes universidades:

    Universidad Nacional De Jujuy
    Universidad de Palermo

Documentar los operators que se deberían utilizar a futuro, teniendo en cuenta que se va a hacer dos consultas SQL (una para cada universidad), se van a procesar los datos con pandas y se van a cargar los datos en S3.  El DAG se debe ejecutar cada 1 hora, todos los días.


   